### PR TITLE
chore: release v0.2.1

### DIFF
--- a/integrations/code/package-lock.json
+++ b/integrations/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zensical-studio",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zensical-studio",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@zip.js/zip.js": "^2.8.26",

--- a/integrations/code/package.json
+++ b/integrations/code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zensical-studio",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "zensical",
   "displayName": "Zensical Studio",
   "description": "Refactor documentation like code",


### PR DESCRIPTION
## Summary

This release improves navigation in the live Markdown preview:

- Relative Markdown links now open the corresponding document in the editor instead of a browser.
- Same-document and cross-document anchor links position the cursor at the linked heading and synchronize the editor and preview.
- External links now display a subtle outbound-link indicator.