### PR TITLE
chore: release v0.2.3

### DIFF
--- a/integrations/code/package-lock.json
+++ b/integrations/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zensical-studio",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zensical-studio",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@zip.js/zip.js": "^2.8.26",

--- a/integrations/code/package.json
+++ b/integrations/code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zensical-studio",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "zensical",
   "displayName": "Zensical Studio",
   "description": "Refactor documentation like code",


### PR DESCRIPTION
## Summary

This version scopes Python Markdown support to the directories managed by the project configuration, such as the `docs_dir` and configured include directories. Markdown files outside those scopes, including project-root `README.md` files, remain under native Markdown support. Users can also switch documents back to Markdown without the extension overriding their choice.