### PR TITLE
chore: release v0.2.4

### DIFF
--- a/integrations/code/package-lock.json
+++ b/integrations/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zensical-studio",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zensical-studio",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@zip.js/zip.js": "^2.8.26",

--- a/integrations/code/package.json
+++ b/integrations/code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zensical-studio",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publisher": "zensical",
   "displayName": "Zensical Studio",
   "description": "Refactor documentation like code",


### PR DESCRIPTION
## Summary

This version of Zensical Studio introduces a new Markdown formatter, smarter links and anchors, and a code action to extract reference definitions.

### Markdown formatting

Zensical Studio can now format Python Markdown and supported extensions directly in your editor. Formatting normalizes common authoring noise while preserving document structure:

- Headings, lists, definition lists, block quotes, tables, code fences, references, footnotes, attribute lists, admonitions, details, and content tabs
- Unordered and ordered list markers, task lists, indentation, and expanded list layout
- Link and footnote definitions grouped at the end of the document
- Trailing whitespace, repeated blank lines, and line-ending style
- Safe inline normalization for supported links, images, titles, emphasis, and inline code

The formatter is **structure-aware**: nested content such as code blocks, tabs, admonitions, and block quotes retains its correct ownership and indentation. It reaches a stable result in one format action, so formatting again produces no further changes.

For safety, template syntax remains untouched, prose is not reflowed, and complex Markdown-enabled HTML tables are preserved as authored.

### Smarter links and anchors

All `#id` values in this example are workspace symbols: Zensical Studio validates links to them, completes them, supports navigation and rename, and updates incoming links after saving an edit:

````markdown
# Heading { #custom-id }

Paragraph content.
{ #paragraph-id }

- List item
  { #item-id }

Term { #term-id }
: Definition text

| Feature |
| --- |
| Anchorable cell { #cell-id } |

```python { #code-id }
print("Anchored code block")
```

<div id="html-id" markdown>
Markdown-enabled HTML content.
</div>
````

If you change the part after `#` in any of these anchors, Zensical Studio will update all links to it across the entire workspace.

### Extract reference definitions

A new code action extracts inline links and images into reference definitions. Zensical Studio prefers shortcut references when possible, uses explicit labels when needed, and appends the new definition to the document’s trailing reference-definition group.