### PR TITLE
chore: release v0.2.6

### DIFF
--- a/integrations/code/package-lock.json
+++ b/integrations/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zensical-studio",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zensical-studio",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@zip.js/zip.js": "^2.8.26",

--- a/integrations/code/package.json
+++ b/integrations/code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zensical-studio",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "publisher": "zensical",
   "displayName": "Zensical Studio",
   "description": "Refactor documentation like code",


### PR DESCRIPTION
## Summary

This version fixes a startup race in which Markdown files opened while the Zensical Studio Visual Studio Code extension was still initializing could remain in regular Markdown mode. Such files now wait in a startup queue and are automatically retagged as Python Markdown once Studio has determined the project’s managed documentation roots.

### Zensical Studio

Zensical Studio has been updated to 0.2.10. 

This version improves support for complex and generated documentation projects. Configured `docs_dir` paths can now resolve outside their configuration directory, including the workspace root, and Studio can discover and index configured projects or documentation roots that are Git-ignored. It also honors `exclude_docs` in both `mkdocs.yml` and `zensical.toml`, keeping excluded pages out of diagnostics, completion, navigation, and link resolution.

Inline links and images can now be extracted into reference definitions from all supported Markdown flow contexts, including tables, admonition titles, and content tabs. Studio also supports TOML 1.1 project configuration files.