### PR TITLE
chore: release v0.2.7

### DIFF
--- a/integrations/code/package-lock.json
+++ b/integrations/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zensical-studio",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zensical-studio",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "MIT",
       "dependencies": {
         "@zip.js/zip.js": "^2.8.26",

--- a/integrations/code/package.json
+++ b/integrations/code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zensical-studio",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "publisher": "zensical",
   "displayName": "Zensical Studio",
   "description": "Refactor documentation like code",


### PR DESCRIPTION
## Summary

This version adds support for Directives – our new Markdown extension that  provides syntax highlighting for block and inline directives, including conditions, catalog values, reusable files, and variables:

``` md
@if deployment = cloud
    Use the managed cloud service.

@use "shared/guide.md"
```

Zensical Studio's Markdown preview now supports switching between configured variants, making it easy to inspect each documentation variant as you write.