### PR TITLE
feature: add word count and reading time estimate

### DIFF
--- a/integrations/code/src/extension.ts
+++ b/integrations/code/src/extension.ts
@@ -34,6 +34,7 @@ import { Context } from "./extension/context";
 import { activateProjectMarkdown } from "./extension/project";
 import { getStudio } from "./extension/studio";
 import { NetworkError } from "./extension/studio/fetch";
+import { WordCount } from "./word-count";
 
 /* ----------------------------------------------------------------------------
  * State
@@ -43,6 +44,9 @@ import { NetworkError } from "./extension/studio/fetch";
  * Language client.
  */
 let client: LanguageClient | undefined;
+
+/** Editor-side prose statistics controller. */
+let wordCount: WordCount | undefined;
 
 /**
  * Startup timer.
@@ -75,6 +79,8 @@ const pending = new Map<string, TextDocument>();
  */
 export async function activate(extension: ExtensionContext): Promise<void> {
   const context = new Context(extension);
+  wordCount = new WordCount(() => client);
+  extension.subscriptions.push(wordCount);
 
   // Register commands
   registerCommands(
@@ -166,6 +172,7 @@ async function startStudio(
         context, client, pending,
       )),
     );
+    wordCount?.refresh();
   } catch (error) {
     if (error instanceof NetworkError) {
       scheduleRetry(extension, context);

--- a/integrations/code/src/preview.ts
+++ b/integrations/code/src/preview.ts
@@ -60,6 +60,9 @@ interface PreviewUpdate {
   version: number;
   html: string;
   mappings: MappingSegment[];
+  words: number;
+  cjkUnits: number;
+  readingSeconds: number;
 };
 
 /**
@@ -139,6 +142,13 @@ let activePanel: vscode.WebviewPanel | undefined;
  * Active preview session.
  */
 let activeSession: string | undefined;
+
+/**
+ * Active preview context used by editor-side document statistics.
+ */
+let activePreviewContext:
+  { uri: string; variant?: string; projections: Record<string, string> }
+  | undefined;
 
 /**
  * Disposable for the preview update notification.
@@ -253,6 +263,11 @@ export function registerPreviewCommand(
         selectedVariant = availableVariants.includes(persisted ?? "")
           ? persisted
           : result?.defaultVariant;
+        activePreviewContext = {
+          uri,
+          variant: selectedVariant,
+          projections: {},
+        };
         if (selectedVariant && availableVariants.includes(selectedVariant)) {
           void context.workspaceState.update(
             variantStateKey(uri), selectedVariant,
@@ -333,6 +348,7 @@ export function registerPreviewCommand(
         activePanel = undefined;
         activeSession = undefined;
         activeUri = undefined;
+        activePreviewContext = undefined;
         notificationDisposable?.dispose();
         notificationDisposable = undefined;
         variantsChangedDisposable.dispose();
@@ -427,6 +443,11 @@ export function registerPreviewCommand(
             const session = activeSession;
             const uri = activeUri;
             selectedVariant = message.variant;
+            activePreviewContext = {
+              uri,
+              variant: selectedVariant,
+              projections: {},
+            };
             void context.workspaceState.update(
               variantStateKey(uri), selectedVariant,
             );
@@ -562,6 +583,7 @@ export function registerPreviewCommand(
             variantUpdateGeneration += 1;
             availableVariants = [];
             selectedVariant = undefined;
+            activePreviewContext = undefined;
             latestVersion = -1;
             latestUpdate = undefined;
             if (updateTimer) {
@@ -585,6 +607,11 @@ export function registerPreviewCommand(
               selectedVariant = availableVariants.includes(persisted ?? "")
                 ? persisted
                 : variants?.defaultVariant;
+              activePreviewContext = {
+                uri,
+                variant: selectedVariant,
+                projections: {},
+              };
               if (selectedVariant && availableVariants.includes(selectedVariant)) {
                 void context.workspaceState.update(
                   variantStateKey(uri), selectedVariant,
@@ -625,6 +652,11 @@ export function registerPreviewCommand(
             // Update the active session and send the initial preview update
             activeSession = result.session;
             activeUri = uri;
+            activePreviewContext = {
+              uri,
+              variant: selectedVariant,
+              projections: {},
+            };
             startingUri = undefined;
             latestVersion = result.initialUpdate.version;
             latestUpdate = result.initialUpdate;
@@ -667,6 +699,20 @@ export function registerPreviewCommand(
       requestSwitch(editor.document);
     }),
   );
+}
+
+/**
+ * Returns the selected context for an active preview document.
+ *
+ * @param uri - The URI of the document
+ *
+ * @returns Active preview context, or undefined if not active
+ */
+export function getActivePreviewContext(
+  uri: string,
+): { variant?: string; projections: Record<string, string> } | undefined {
+  if (activePreviewContext?.uri !== uri) return undefined;
+  return activePreviewContext;
 }
 
 /* ------------------------------------------------------------------------- */

--- a/integrations/code/src/word-count.ts
+++ b/integrations/code/src/word-count.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Zensical and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ * All contributions are certified under the DCO
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import * as vscode from "vscode";
+import type { Disposable } from "vscode";
+import type { LanguageClient } from "vscode-languageclient/node";
+
+import { getActivePreviewContext } from "./preview";
+
+/* ----------------------------------------------------------------------------
+ * Types
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Document statistics returned by the language server.
+ */
+interface DocumentStats {
+  uri: string;
+  words: number;
+  cjkUnits?: number;
+  readingSeconds?: number;
+  variant?: string;
+}
+
+/* ----------------------------------------------------------------------------
+ * Data
+ * ------------------------------------------------------------------------- */
+
+const documentStats = "zensical/document/stats";
+const REQUEST_DELAY = 200;
+const WORDS_PER_MINUTE = 200;
+
+/* ----------------------------------------------------------------------------
+ * Class
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Shows visible prose statistics for the active Studio document.
+ */
+export class WordCount implements Disposable {
+  private readonly item = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Right,
+    100,
+  );
+  private readonly disposables: Disposable[] = [];
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private generation = 0;
+
+  /**
+   * Creates the word count status bar item.
+   */
+  public constructor(
+    private readonly getClient: () => LanguageClient | undefined,
+  ) {
+    this.item.name = "Zensical Studio word count";
+    this.disposables.push(
+      this.item,
+      vscode.window.onDidChangeActiveTextEditor(() => this.refresh()),
+      vscode.workspace.onDidChangeTextDocument((event) => {
+        if (
+          event.document === vscode.window.activeTextEditor?.document
+        ) {
+          this.refresh();
+        }
+      }),
+    );
+    this.refresh();
+  }
+
+  /**
+   * Refreshes the word count status bar item.
+   */
+  public refresh(): void {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      void this.update();
+    }, REQUEST_DELAY);
+  }
+
+  /**
+   * Disposes the item.
+   */
+  public dispose(): void {
+    if (this.timer) clearTimeout(this.timer);
+    for (const disposable of this.disposables) disposable.dispose();
+  }
+
+  /**
+   * Updates the word count status bar item.
+   */
+  private async update(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    const client = this.getClient();
+    if (!editor || editor.document.languageId !== "python-markdown" || !client) {
+      this.item.hide();
+      return;
+    }
+
+    // Increment generation to cancel any pending requests
+    const uri = editor.document.uri.toString();
+    const generation = ++this.generation;
+    const preview = getActivePreviewContext(uri);
+    const params = {
+      uri,
+      projections: preview?.projections ?? {},
+      ...(preview?.variant ? { variant: preview.variant } : {}),
+    };
+    try {
+      const result = await client.sendRequest<DocumentStats>(
+        documentStats,
+        params,
+      );
+      if (
+        generation !== this.generation ||
+        vscode.window.activeTextEditor?.document.uri.toString() !== uri
+      ) {
+        return;
+      }
+      const minutes = Math.ceil(getReadingSeconds(result) / 60);
+      this.item.text = `$(book) ${formatNumber(result.words)} · ${minutes} min`;
+      this.item.tooltip = undefined;
+      this.item.show();
+    } catch {
+      if (generation === this.generation) {
+        this.item.hide();
+      }
+    }
+  }
+}
+
+/* ----------------------------------------------------------------------------
+ * Functions
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Formats a number with commas as thousands separators.
+ *
+ * @param value - Number to format
+ *
+ * @returns Formatted number
+ */
+function formatNumber(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+/**
+ * Calculates the reading time in seconds.
+ *
+ * @param stats - Document statistics
+ *
+ * @returns Reading time in seconds
+ */
+function getReadingSeconds(stats: DocumentStats): number {
+  return stats.readingSeconds ?? Math.ceil(stats.words / WORDS_PER_MINUTE) * 60;
+}


### PR DESCRIPTION
This PR adds live word count and reading time estimates with support for CJK languages, only taking the visible text into account, allowing to quickly assess the length and investment of reading time into a document.