### PR TITLE
chore: release v0.2.12

### DIFF
--- a/integrations/code/package-lock.json
+++ b/integrations/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zensical-studio",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zensical-studio",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "license": "MIT",
       "dependencies": {
         "@zip.js/zip.js": "^2.8.26",

--- a/integrations/code/package.json
+++ b/integrations/code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zensical-studio",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "publisher": "zensical",
   "displayName": "Zensical Studio",
   "description": "Refactor documentation like code",


### PR DESCRIPTION
## Summary

This version adds project-navigation intelligence for Zensical Studio. Navigation paths in both `mkdocs.yml` and `zensical.toml` now participate in completion, validation, references, and file-rename propagation. Studio updates navigation entries when Markdown files are renamed or moved in the editor, including open configuration buffers with unrelated unsaved edits. It also recovers safe external moves, covering directory moves and uniquely identifiable single-file Markdown moves.