### PR TITLE
fix: don't auto-close backticks inside code spans

### DIFF
--- a/integrations/code/language.json
+++ b/integrations/code/language.json
@@ -32,7 +32,10 @@
     },
     {
       "open": "`",
-      "close": "`"
+      "close": "`",
+      "notIn": [
+        "string"
+      ]
     },
     {
       "open": "<",


### PR DESCRIPTION
Typing ``` to start a fenced code block produced a spurious fourth backtick: the first \` is auto-closed, the second \` overtypes the inserted close, and the editor then auto-closes a pair again on the third backtick.

Suppress auto-closing of the backtick pair when the token before the cursor is a string token via `notIn: ["string"]`. Two backticks open an inline code span scoped `markup.inline.raw.string.markdown`, so the third backtick no longer triggers auto-closing and code blocks type cleanly, while the single-backtick auto-pair for inline code in prose is preserved. `surroundingPairs` is unchanged, so wrapping a selection in backticks still works.

Four-or-more backtick fences keep inserting one extra backtick: fence punctuation is scoped `markup.fenced_code.block.markdown` (not string), so auto-closing remains enabled there. This matches the previous behavior.

References: microsoft/vscode hit the same problem for built-in markdown and ended up removing the backtick pairs entirely, as `autoClosingPairs` offered no way to fix it:

- https://github.com/microsoft/vscode/issues/192676
- https://github.com/microsoft/vscode/pull/184532 (add ` and ``` pairs)
- https://github.com/microsoft/vscode/pull/202290 (revert ``` pair)
- https://github.com/microsoft/vscode/pull/203487 (also drop ` pair)

`notIn: ["string"]` avoids that outcome for Python Markdown.